### PR TITLE
Update Main.strings

### DIFF
--- a/localization/nl.lproj/Main.strings
+++ b/localization/nl.lproj/Main.strings
@@ -134,7 +134,7 @@
 "uQy-DD-JDr.title" = "Middle";
 
 /* Class = "NSTextFieldCell"; title = "Go to System Preferences  → Security & Privacy → Privacy → Accessibility"; ObjectID = "vCt-Cm-ARK"; */
-"vCt-Cm-ARK.title" = "Ga naar Systeemvoorkeuren → Beveiliging en Geheimhouding → Geheimhouding → Toegankelijkheid";
+"vCt-Cm-ARK.title" = "Ga naar Systeemvoorkeuren → Beveiliging en privacy → Privacy → Toegankelijkheid";
 
 /* Class = "NSMenuItem"; title = "Show viewer…"; ObjectID = "vZH-gr-9dX"; */
 "vZH-gr-9dX.title" = "Viewer tonen…";


### PR DESCRIPTION
Make the translation more accurate to what it is in MacOS currently.

![image](https://user-images.githubusercontent.com/32953684/144089181-9857c2e4-5bf1-430f-a98a-880c54278b48.png)

It says "Beveiliging en privacy" instead of "Beveiliging en Geheimhouding".